### PR TITLE
pokemon-db에서 http를 https로 redirect 시키기

### DIFF
--- a/service/pokemon-db.yml
+++ b/service/pokemon-db.yml
@@ -62,6 +62,8 @@ kind: Ingress
 metadata:
   name: pokemon-db
   namespace: pokemon-db
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   tls:
     - hosts: ['pokemon.upnl.org']


### PR DESCRIPTION
Reference: https://docs.traefik.io/v1.7/configuration/backends/kubernetes/#security-headers-annotations