### PR TITLE
Update PV mount position

### DIFF
--- a/service/helix.yml
+++ b/service/helix.yml
@@ -37,7 +37,8 @@ spec:
         image: postgres:9.3-alpine
         volumeMounts:
         - name: db
-          mountPath: /var/lib/postgresql
+          mountPath: /var/lib/postgresql/data
+          subPath: postgres
         envFrom:
         - secretRef:
             name: env


### PR DESCRIPTION
정확한 원인은 불명이지만, postgres 컨테이너가 PV 안에 데이터를 쓰지 못하고 컨테이너 자체 저장소에만 쓰는 문제가 발생하고 있습니다.

image 내에 이미 정의되어있는 폴더와 pv 내에 있는 폴더가 겹치면 pv를 보지 못하는 것으로 추측됩니다.

그래서 경로가 겹치지 않도록 mount 위치를 조정합니다.